### PR TITLE
Add missing dependency declaration on Magento_Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2021-07-21
+
+### Added
+- Added `Magento_Store` as hard dependency [#1](https://github.com/markshust/magento2-module-extrabodyclasses/pull/1).
+
 ## [1.0.1] - 2019-11-14
 
-### Changed
+### Updated
 - Changed the listened event from `controller_action_predispatch` to `layout_load_before`. This fixes some issues which
   may arise from conflicts with third-party modules. 
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "magento/module-store": "^100|^101"
   },
   "type": "magento2-module",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": [
     "MIT"
   ],

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
   "description": "The Extra Body Classes module adds the website and store codes to the body class attribute.",
   "require": {
     "php": "^7.1",
-    "magento/framework": "^102"
+    "magento/framework": "^102",
+    "magento/module-store": "^100|^101"
   },
   "type": "magento2-module",
   "version": "1.0.1",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="MarkShust_ExtraBodyClasses"/>
+    <module name="MarkShust_ExtraBodyClasses">
+        <sequence>
+            <module name="Magento_Store"/>
+        </sequence>
+    </module>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="MarkShust_ExtraBodyClasses">
-        <sequence>
-            <module name="Magento_Store"/>
-        </sequence>
-    </module>
+    <module name="MarkShust_ExtraBodyClasses"/>
 </config>


### PR DESCRIPTION
Codebase depends on:

* StoreManagerInterface's getWebsite() and getStore() methods
* WebsiteInterface's getCode() method
* StoreInterface's getCode() method

Usage: https://github.com/markshust/magento2-module-extrabodyclasses/blob/master/Observer/AddCodesToBodyClass.php#L39-L40

These exist in versions 100 and 101 and are a major version dependency.